### PR TITLE
This mistake existed for over ten months

### DIFF
--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -1610,13 +1610,13 @@ public static class Options
         // Decontamination time on MiraHQ
         DecontaminationTimeOnMiraHQ = new FloatOptionItem(60504, "DecontaminationTimeOnMiraHQ", new(0.5f, 10f, 0.25f), 3f, TabGroup.GameSettings)
             .SetParent(ChangeDecontaminationTime)
-            .SetValueFormat(OptionFormat.Multiplier)
+            .SetValueFormat(OptionFormat.Seconds)
             .SetColor(new Color32(19, 188, 233, byte.MaxValue));
 
         // Decontamination time on Polus
         DecontaminationTimeOnPolus = new FloatOptionItem(60505, "DecontaminationTimeOnPolus", new(0.5f, 10f, 0.25f), 3f, TabGroup.GameSettings)
             .SetParent(ChangeDecontaminationTime)
-            .SetValueFormat(OptionFormat.Multiplier)
+            .SetValueFormat(OptionFormat.Seconds)
             .SetColor(new Color32(19, 188, 233, byte.MaxValue));
 
 


### PR DESCRIPTION
Decontamination time on Mira/Polus settings' value format was accidentally set to Multiplier instead of Seconds