### PR TITLE
Add Discord webhook filter workflow

### DIFF
--- a/.github/workflows/discord_webhook_filter.yml
+++ b/.github/workflows/discord_webhook_filter.yml
@@ -1,0 +1,189 @@
+name: Discord Webhook Filter
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, ready_for_review]
+    branches: [ main ]
+  pull_request_review:
+    types: [submitted]
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+  push:
+    branches: [ main ]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check if notification should be sent
+        id: filter
+        run: |
+          SHOULD_NOTIFY="true"
+          
+          # Check if this is the source file update commit we want to see
+          IS_SOURCE_UPDATE="false"
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            COMMIT_MSG="${{ github.event.head_commit.message || github.event.pull_request.title }}"
+            if echo "${COMMIT_MSG}" | grep -q "Update source file en_US.json"; then
+              IS_SOURCE_UPDATE="true"
+              echo "Allowing: Source file update detected"
+            fi
+          fi
+          
+          # Skip translation branch activity UNLESS it's the source file update
+          if [[ "${{ github.head_ref }}" == "translation" ]] || [[ "${{ github.ref }}" == "refs/heads/translation" ]]; then
+            if [[ "${IS_SOURCE_UPDATE}" == "false" ]]; then
+              echo "Skipping: Translation branch activity (not source file update)"
+              SHOULD_NOTIFY="false"
+            fi
+          fi
+          
+          # For workflow_run events from translation branch, always skip (these are the "checks skipped" messages)
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            if [[ "${{ github.event.workflow_run.head_branch }}" == "translation" ]]; then
+              echo "Skipping: Workflow run on translation branch"
+              SHOULD_NOTIFY="false"
+            fi
+          fi
+          
+          echo "should_notify=${SHOULD_NOTIFY}" >> $GITHUB_OUTPUT
+          
+      - name: Send Discord notification
+        if: steps.filter.outputs.should_notify == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          # Prepare notification based on event type
+          case "${{ github.event_name }}" in
+            pull_request)
+              PR_NUM="${{ github.event.pull_request.number }}"
+              PR_TITLE="${{ github.event.pull_request.title }}"
+              PR_USER="${{ github.event.pull_request.user.login }}"
+              PR_URL="${{ github.event.pull_request.html_url }}"
+              
+              case "${{ github.event.action }}" in
+                opened)
+                  TITLE="New Pull Request"
+                  COLOR="3447003"
+                  DESCRIPTION="**${PR_TITLE}**\n\n${PR_USER} opened [PR #${PR_NUM}](${PR_URL})"
+                  ;;
+                closed)
+                  if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+                    TITLE="Pull Request Merged"
+                    COLOR="5763719"
+                    DESCRIPTION="**${PR_TITLE}**\n\n[PR #${PR_NUM}](${PR_URL}) was merged into main"
+                  else
+                    TITLE="Pull Request Closed"
+                    COLOR="15158332"
+                    DESCRIPTION="**${PR_TITLE}**\n\n[PR #${PR_NUM}](${PR_URL}) was closed without merging"
+                  fi
+                  ;;
+                synchronize)
+                  TITLE="Pull Request Updated"
+                  COLOR="16776960"
+                  DESCRIPTION="**${PR_TITLE}**\n\nNew commits pushed to [PR #${PR_NUM}](${PR_URL})"
+                  ;;
+                ready_for_review)
+                  TITLE="Pull Request Ready for Review"
+                  COLOR="16776960"
+                  DESCRIPTION="**${PR_TITLE}**\n\n[PR #${PR_NUM}](${PR_URL}) is ready for review"
+                  ;;
+                reopened)
+                  TITLE="Pull Request Reopened"
+                  COLOR="16776960"
+                  DESCRIPTION="**${PR_TITLE}**\n\n[PR #${PR_NUM}](${PR_URL}) was reopened"
+                  ;;
+              esac
+              URL="${PR_URL}"
+              ;;
+              
+            workflow_run)
+              WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+              WORKFLOW_CONCLUSION="${{ github.event.workflow_run.conclusion }}"
+              WORKFLOW_BRANCH="${{ github.event.workflow_run.head_branch }}"
+              WORKFLOW_URL="${{ github.event.workflow_run.html_url }}"
+              
+              if [[ "${WORKFLOW_CONCLUSION}" == "success" ]]; then
+                TITLE="${WORKFLOW_NAME} Successful"
+                COLOR="5763719"
+                DESCRIPTION="Branch: \`${WORKFLOW_BRANCH}\`\n\n[View workflow run](${WORKFLOW_URL})"
+              elif [[ "${WORKFLOW_CONCLUSION}" == "failure" ]]; then
+                TITLE="${WORKFLOW_NAME} Failed"
+                COLOR="15158332"
+                DESCRIPTION="Branch: \`${WORKFLOW_BRANCH}\`\n\n[View workflow run](${WORKFLOW_URL})"
+              else
+                TITLE="${WORKFLOW_NAME} ${WORKFLOW_CONCLUSION}"
+                COLOR="16776960"
+                DESCRIPTION="Branch: \`${WORKFLOW_BRANCH}\`\n\n[View workflow run](${WORKFLOW_URL})"
+              fi
+              URL="${WORKFLOW_URL}"
+              ;;
+              
+            pull_request_review)
+              REVIEW_USER="${{ github.event.review.user.login }}"
+              REVIEW_STATE="${{ github.event.review.state }}"
+              PR_NUM="${{ github.event.pull_request.number }}"
+              PR_TITLE="${{ github.event.pull_request.title }}"
+              REVIEW_URL="${{ github.event.review.html_url }}"
+              
+              case "${REVIEW_STATE}" in
+                approved)
+                  TITLE="Pull Request Approved"
+                  COLOR="5763719"
+                  ;;
+                changes_requested)
+                  TITLE="Changes Requested"
+                  COLOR="16776960"
+                  ;;
+                commented)
+                  TITLE="Review Comment"
+                  COLOR="3447003"
+                  ;;
+              esac
+              DESCRIPTION="**${PR_TITLE}**\n\n${REVIEW_USER} reviewed [PR #${PR_NUM}](${REVIEW_URL})"
+              URL="${REVIEW_URL}"
+              ;;
+              
+            push)
+              PUSHER="${{ github.event.pusher.name }}"
+              COMMIT_MSG="${{ github.event.head_commit.message }}"
+              COMMIT_URL="${{ github.event.head_commit.url }}"
+              BRANCH="${{ github.ref_name }}"
+              
+              TITLE="Push to ${BRANCH}"
+              COLOR="3447003"
+              # Truncate commit message if too long
+              SHORT_MSG=$(echo "${COMMIT_MSG}" | head -n 1 | cut -c1-100)
+              DESCRIPTION="${PUSHER}: ${SHORT_MSG}\n\n[View commit](${COMMIT_URL})"
+              URL="${COMMIT_URL}"
+              ;;
+          esac
+          
+          # Escape special characters for JSON
+          TITLE=$(echo "${TITLE}" | sed 's/"/\\"/g')
+          DESCRIPTION=$(echo "${DESCRIPTION}" | sed 's/"/\\"/g')
+          
+          # Send Discord webhook
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"${TITLE}\",
+                \"description\": \"${DESCRIPTION}\",
+                \"url\": \"${URL}\",
+                \"color\": ${COLOR},
+                \"footer\": {
+                  \"text\": \"${{ github.repository }}\"
+                },
+                \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)\"
+              }]
+            }" \
+            "${DISCORD_WEBHOOK}")
+          
+          if [[ "${HTTP_STATUS}" -ge 200 ]] && [[ "${HTTP_STATUS}" -lt 300 ]]; then
+            echo "Notification sent successfully (HTTP ${HTTP_STATUS})"
+          else
+            echo "Failed to send notification (HTTP ${HTTP_STATUS})"
+            exit 1
+          fi


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to filter Discord notifications and reduce channel noise from automated translation updates.

## Changes

- New workflow: `.github/workflows/discord_webhook_filter.yml`
- Filters out translation branch activity except source file updates
- Blocks "checks skipped" spam from Build workflow
- Maintains notifications for Crowdin PRs and important events

## Behavior

**Notifications will be sent for:**
- Pull requests (opened, merged, closed, reviews)
- Crowdin PRs
- Source file updates ("Update source file en_US.json")
- Build workflow results (success/failure) on non-translation branches
- Direct commits to main branch

**Notifications will NOT be sent for:**
- Translation branch commits (except source file updates)
- Build workflow "checks skipped" messages
- Other translation branch activity

## Setup Required

After merging, add the Discord webhook URL as a repository secret:

1. Go to Settings → Secrets and variables → Actions
2. Create new secret: `DISCORD_WEBHOOK_URL`
3. Paste your Discord webhook URL

## Testing

The workflow can be tested by:
- Creating a test PR from a feature branch
- Pushing a source file update to the translation branch
- Verifying no notifications for other translation branch commits