### PR TITLE
Build Steam ZIP using x86 BepInEx & Add automatic Discord #releases ping on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,4 +234,4 @@ jobs:
           curl -H "Content-Type: application/json" \
             -X POST \
             -d "{\"content\": \"<@&1170671991343288391>\nEHR v${{ github.event.inputs.version }}\nhttps://github.com/${{ github.repository }}/releases/tag/v${{ github.event.inputs.version }}\"}" \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
+            ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}


### PR DESCRIPTION
Turns out the steam version used x86 BepInEx all along, my bad! I've built and compared the two and this should fix the problems with the mod not loading at all

I also added the discord ping, should work just fine - **please add the DISCORD_RELEASE_WEBHOOK_URL secret to actions**, and optionally do the test I dmed you to make sure the command is set up right