### PR TITLE
Fix Flashing Dead Player State In Meeting

### DIFF
--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -1242,7 +1242,7 @@ internal static class MeetingHudUpdatePatch
                 BufferTime = 10;
                 CustomRoles myRole = PlayerControl.LocalPlayer.GetCustomRole();
 
-                __instance.playerStates.Where(x => (!Main.PlayerStates.TryGetValue(x.TargetPlayerId, out PlayerState ps) || ps.IsDead) && !x.AmDead).Do(x => x.SetDead(x.DidReport, true));
+                //__instance.playerStates.Where(x => (!Main.PlayerStates.TryGetValue(x.TargetPlayerId, out PlayerState ps) || ps.IsDead) && !x.AmDead).Do(x => x.SetDead(x.DidReport, true));
 
                 switch (myRole)
                 {


### PR DESCRIPTION
I don't know how to explain this bug
After guessing, dead players very quickly switch from dead to alive and vice versa
<img width="98" height="102" alt="image" src="https://github.com/user-attachments/assets/dcb77fed-7135-4d3b-938c-44cb8bb8b9f3" />
<img width="104" height="90" alt="image" src="https://github.com/user-attachments/assets/4efeea8c-a2c0-47c1-801f-43beddf20df7" />

I encountered this bug back when I was developing TOHE, and when I removed this code, the bug disappeared, but I still haven't found a reasonable explanation for why the bug occurs

