### PR TITLE
Change unload to deactivate only current plugin

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -177,7 +177,7 @@ public class Main : BasePlugin
     private static HashAuth DebugKeyAuth { get; set; }
     private static ConfigEntry<string> DebugKeyInput { get; set; }
 
-    private Harmony Harmony { get; } = new(PluginGuid);
+    public Harmony Harmony { get; } = new(PluginGuid);
 
     public static NormalGameOptionsV10 NormalOptions => GameOptionsManager.Instance != null ? GameOptionsManager.Instance.currentNormalGameOptions : null;
 

--- a/Patches/ClientOptionsPatch.cs
+++ b/Patches/ClientOptionsPatch.cs
@@ -123,7 +123,7 @@ public static class OptionsMenuBehaviourStartPatch
                 {
                     MainMenuManagerPatch.ShowRightPanelImmediately();
 
-                    Harmony.UnpatchAll();
+                    Main.Instance.Harmony.UnpatchSelf();
                     Main.Instance.Unload();
                 }
             }

--- a/Patches/GameOptionsPatch.cs
+++ b/Patches/GameOptionsPatch.cs
@@ -33,7 +33,7 @@ internal static class SwitchGameModePatch
         }
 
         Zoom.SetZoomSize(reset: true);
-        Harmony.UnpatchAll();
+        Main.Instance.Harmony.UnpatchSelf();
         Main.Instance.Unload();
     }
 }


### PR DESCRIPTION
Previously, unloading the mod cleared all Harmony patches, affecting other plugins.
This change how unload behavior works to only deactivate the patches of the current plugin, leaving other patches intact.