### PR TITLE
Fix: Resolved permanent camouflage when Camouflager is recruited mid-ability

### DIFF
--- a/Roles/Standard/Impostor/Support/Camouflager.cs
+++ b/Roles/Standard/Impostor/Support/Camouflager.cs
@@ -64,6 +64,11 @@ public class Camouflager : RoleBase
         On = true;
     }
 
+    public override void Remove(byte playerId)
+    {
+        if (IsActive) IsDead();
+    }
+
     public override bool OnShapeshift(PlayerControl pc, PlayerControl target, bool shapeshifting)
     {
         if (!shapeshifting)


### PR DESCRIPTION
Resolves the bug reported in [this thread](https://discord.com/channels/1039487420757966858/1493226895888875651). 

Note: `Camouflager.IsDead()` is a pretty misleading name, as it doesn't check or require the player to be dead, it just resets `IsActive` and calls `CheckCamouflage()`. Happy to do a follow-up commit renaming it to something like `CancelCamouflage()` if wanted.