### PR TITLE
Add "meeting" Property to Template System

### DIFF
--- a/Modules/TemplateManager.cs
+++ b/Modules/TemplateManager.cs
@@ -78,13 +78,14 @@ public static class TemplateManager
         public int Delay { get; init; }
         public bool Hidden { get; init; }
         public HashSet<MapNames> AllowedMaps { get; init; }
+        public HashSet<int> AllowedMeetings { get; init; }
         public HashSet<string> AllowedRoles { get; init; }
         public HashSet<string> AllowedRanks { get; init; }
         public HashSet<int> AllowedPresets { get; init; }
         public string PlayerCountOp { get; init; }
         public int PlayerCountVal { get; init; }
 
-        public bool MatchesContext() => MatchesMap() && MatchesPlayerCount() && MatchesPreset();
+        public bool MatchesContext() => MatchesMap() && MatchesMeeting() && MatchesPlayerCount() && MatchesPreset();
 
         public bool MatchesRole(PlayerControl player)
         {
@@ -119,7 +120,8 @@ public static class TemplateManager
         }
 
         private bool MatchesMap() => AllowedMaps == null || AllowedMaps.Contains(Main.CurrentMap);
-
+        private bool MatchesMeeting() => AllowedMeetings == null || AllowedMeetings.Contains(MeetingStates.MeetingNum);
+        
         private bool MatchesPlayerCount()
         {
             if (PlayerCountOp == null) return true;
@@ -255,6 +257,7 @@ public static class TemplateManager
         int delay = 0;
         bool hidden = props.ContainsKey("hidden");
         HashSet<MapNames> allowedMaps = null;
+        HashSet<int> allowedMeetings = null;
         HashSet<string> allowedRoles = null;
         HashSet<string> allowedRanks = null;
         HashSet<int> allowedPresets = null;
@@ -273,6 +276,14 @@ public static class TemplateManager
             foreach (string part in mapStr.TrimStart('=').Split('|'))
                 if (Enum.TryParse(part.Trim(), ignoreCase: true, out MapNames map))
                     allowedMaps.Add(map);
+        }
+
+        if (props.TryGetValue("meeting", out string meetingStr))
+        {
+            allowedMeetings = [];
+            foreach (string part in meetingStr.TrimStart('=').Split('|'))
+                if (int.TryParse(part.Trim(), out int meeting))
+                    allowedMeetings.Add(meeting);
         }
 
         if (props.TryGetValue("role", out string roleStr))
@@ -307,6 +318,7 @@ public static class TemplateManager
             Delay = delay,
             Hidden = hidden,
             AllowedMaps = allowedMaps,
+            AllowedMeetings = allowedMeetings,
             AllowedRoles = allowedRoles,
             AllowedRanks = allowedRanks,
             AllowedPresets = allowedPresets,


### PR DESCRIPTION
Adds a `meeting` property to the template system to restrict templates to
specific meeting numbers.

### Usage:
`OnMeeting` without any property still triggers on every meeting as usual.
`OnFirstMeeting` continues to work as before for the first meeting specifically.
Use the `meeting` property when you need to target a specific meeting number:

OnMeeting[meeting=2]: This is sent on Meeting 2
OnMeeting[meeting=3|4]: This is sent on Meeting 3 or 4

Multiple meeting numbers can be specified using `|` as a separator.