### PR TITLE
Fix LevelImposter detection by using full plugin GUID

### DIFF
--- a/Patches/MainMenuManagerPatch.cs
+++ b/Patches/MainMenuManagerPatch.cs
@@ -174,7 +174,7 @@ public static class MainMenuManagerPatch
 
         foreach (string buttonName in new[] { "SettingsButton", "Inventory Button", "CreditsButton", "ExitGameButton" })
         {
-            if (buttonName == "Inventory Button" && IL2CPPChainloader.Instance.Plugins.ContainsKey("LevelImposter")) continue;
+            if (buttonName == "Inventory Button" && IL2CPPChainloader.Instance.Plugins.ContainsKey("com.DigiWorm.LevelImposter")) continue;
             var go = GameObject.Find(buttonName);
             if (!go) continue;
             var buttonText = go.GetComponentInChildren<TMP_Text>();


### PR DESCRIPTION
LevelImposter check was using `LevelImposter` instead of the actual BepInEx plugin GUID, causing the lookup to always fail.

Replaced:
`LevelImposter` → `com.DigiWorm.LevelImposter`

`IL2CPPChainloader.Instance.Plugins` is keyed by plugin GUID, not name, so `ContainsKey` requires an exact match.

Thanks to @DigiWorm0 for pointing this out!