### PR TITLE
Block Android joystick input when ClientControlGUI is open

### DIFF
--- a/Modules/ClientControlGUI.cs
+++ b/Modules/ClientControlGUI.cs
@@ -24,6 +24,16 @@ public class ClientControlGUI : MonoBehaviour
     public bool IsOpen;
 
     /// <summary>
+    /// The screen rect of the open panel or if the panel is closed
+    /// </summary>
+    public static Rect PanelRect => Instance != null && Instance.IsOpen ? Instance._windowRect : Rect.zero;
+
+    /// <summary>
+    /// The screen rect of the toggle button
+    /// </summary>
+    public static Rect ToggleRect { get; private set; }
+
+    /// <summary>
     /// Current scroll position inside the panel
     /// </summary>
     private Vector2 _scroll;
@@ -308,6 +318,7 @@ public class ClientControlGUI : MonoBehaviour
             y = Screen.height - size - 10f * Scale;
         }
 
+        ToggleRect = new Rect(x, y, size, size);
         // 90% transparent when in game and panel is closed, full opacity otherwise
         bool fadeOut = !IsOpen && (GameStates.IsInGame || GameSettingMenu.Instance);
         Color prev = GUI.color;

--- a/Patches/JoystickBlockPatch.cs
+++ b/Patches/JoystickBlockPatch.cs
@@ -1,0 +1,37 @@
+using System;
+using HarmonyLib;
+using UnityEngine;
+
+namespace EHR.Patches;
+
+[HarmonyPatch]
+public static class JoystickBlockPatch
+{
+    private static bool ShouldBlockJoystickInput()
+    {
+        if (!OperatingSystem.IsAndroid()) return false;
+        if (!ClientControlGUI.Instance || !ClientControlGUI.Instance.IsOpen) return false;
+
+        foreach (Touch touch in Input.touches)
+        {
+            Vector2 guiPos = new(touch.position.x, Screen.height - touch.position.y);
+            if (ClientControlGUI.PanelRect.Contains(guiPos) || ClientControlGUI.ToggleRect.Contains(guiPos))
+                return true;
+        }
+
+        return false;
+    }
+
+    [HarmonyPatch(typeof(VirtualJoystickController), nameof(VirtualJoystickController.CheckDrag))]
+    [HarmonyPrefix]
+    public static bool VirtualJoystickCheckDrag(ref DragState __result)
+    {
+        if (!ShouldBlockJoystickInput()) return true;
+        __result = DragState.NoTouch;
+        return false;
+    }
+
+    [HarmonyPatch(typeof(ScreenJoystick), "FixedUpdate")]
+    [HarmonyPrefix]
+    public static bool ScreenJoystickFixedUpdate() => !ShouldBlockJoystickInput();
+}


### PR DESCRIPTION
On Android, touching the ClientControlGUI overlay would simultaneously move the 
joystick behind it, since **VirtualJoystick** (the virtual circle joystick) and 
**ScreenJoystick** (the tap-anywhere joystick) use completely independent controllers.

To fix this, `VirtualJoystickController.CheckDrag` and `ScreenJoystick.FixedUpdate` 
are patched to block joystick input when any active touch lands within the panel 
or toggle button rect while the GUI is open.