### PR TITLE
Fix Template System Regex And Minor Improvements

### DIFF
--- a/Modules/TemplateManager.cs
+++ b/Modules/TemplateManager.cs
@@ -237,7 +237,7 @@ public static class TemplateManager
                                       """, RegexOptions.IgnoreCase);
         if (m.Success)
         {
-            value = Regex.Unescape(m.Groups[1].Value);
+            value = m.Groups[1].Value;
             remaining = (input[..m.Index] + input[(m.Index + m.Length)..]).Trim(',').Trim();
             return remaining;
         }

--- a/Modules/TemplateManager.cs
+++ b/Modules/TemplateManager.cs
@@ -396,6 +396,7 @@ public static class TemplateManager
         _cachedEntries = null;
         _cachedTags = null;
         _cachedUserVars = null;
+        RegexCache.Clear();
     }
 
     private static (Dictionary<string, List<TemplateEntry>> Entries, HashSet<string> Tags, Dictionary<string, string> UserVars) GetParsedFile()

--- a/Modules/TemplateManager.cs
+++ b/Modules/TemplateManager.cs
@@ -205,7 +205,11 @@ public static class TemplateManager
     private static string GetResourcesTxt(string path)
     {
         Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(path);
-        if (stream == null) return string.Empty;
+        if (stream == null) 
+        {
+            Logger.Error($"Embedded Resource not found: {path}", "TemplateManager");
+            return string.Empty;
+        }
         stream.Position = 0;
         using StreamReader reader = new(stream, Encoding.UTF8);
         return reader.ReadToEnd();


### PR DESCRIPTION
- Fixed `regex` property not working with backslash sequences like `\s`, `\d`, `\b`. This was caused by `Regex.Unescape()` being called on the pattern before passing it to the regex engine
- Added a warning log when an embedded resource file is not found in `GetResourcesTxt` instead of silently writing a blank template file
- Clear `RegexCache` in `InvalidateCache()` so stale entries don't linger after the template file is edited