### PR TITLE
Change regex property to be case sensitive by default

### DIFF
--- a/Modules/TemplateManager.cs
+++ b/Modules/TemplateManager.cs
@@ -161,7 +161,7 @@ public static class TemplateManager
 
         try
         {
-            Regex rx = new(pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
+            Regex rx = new(pattern, RegexOptions.Compiled, TimeSpan.FromMilliseconds(100));
             RegexCache[pattern] = rx;
             return rx;
         }


### PR DESCRIPTION
Changed template regex matching to be case-sensitive by default instead of globally case-insensitive.

Case-insensitive matching can still be enabled per-pattern using standard .NET inline regex flags such as "(?i)".