### PR TITLE
Resolve most game crashes due to GameOptionsMenuPatch

### DIFF
--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -1690,4 +1690,4 @@ public static class FixDarkThemeForSearchBar
             field.textArea.outputText.color = Color.white;
         }
     }
-    
+}

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -251,6 +251,7 @@ public static class GameOptionsMenuPatch
                 __instance.ControllerSelectable.Add(x);
             
             Canvas.ForceUpdateCanvases();
+            _buildCoroutines.Remove(__instance);
         }
 
         float CalculateScrollBarYBoundsMax()
@@ -418,13 +419,13 @@ public static class GameOptionsMenuPatch
             {
                 if (gen != _reCreateGeneration) yield break;
 
-                // Stop any build coroutine that started during the yield before touching this tab
+                // Wait for any in-progress build coroutine on this tab to finish before recreating
                 if (GameSettingMenuPatch.ModSettingsTabs.TryGetValue(tab, out GameOptionsMenu menu) && menu)
                 {
-                    if (_buildCoroutines.TryGetValue(menu, out Coroutine existing) && existing != null)
+                    while (_buildCoroutines.TryGetValue(menu, out Coroutine existing) && existing != null)
                     {
-                        menu.StopCoroutine(existing);
-                        _buildCoroutines.Remove(menu);
+                        if (gen != _reCreateGeneration) yield break;
+                        yield return null;
                     }
                 }
 

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -496,14 +496,15 @@ public static class GameOptionsMenuPatch
                     toggleOption.CheckMark.transform.parent.FindChild("ActiveSprite").GetComponent<SpriteRenderer>().color = color;
                     break;
                 case StringOptionItem stringOptionItem when optionBehaviour is StringOption stringOption:
-                    // Set Value directly without calling UpdateValue() to avoid re-entering the patch pipeline
                     stringOption.Value = stringOptionItem.GetInt();
                     stringOption.oldValue = stringOption.Value;
                     string selection = stringOptionItem.Selections[stringOptionItem.Rule.GetValueByIndex(stringOption.Value)];
                     if (!stringOptionItem.noTranslation) selection = Translator.GetString(selection);
                     stringOption.ValueText.SetText(selection);
-                    // Re-initialize to restore styled role name (size, color) after preset switch
-                    stringOption.Initialize();
+                    if (!StringOptionPatch.NameCache.ContainsKey(stringOption))
+                        stringOption.Initialize();
+                    else
+                        stringOption.TitleText.SetText(StringOptionPatch.NameCache[stringOption]);
                     break;
                 case FloatOptionItem or IntegerOptionItem when optionBehaviour is NumberOption numberOption:
                     numberOption.Value = optionItem.GetFloat();
@@ -808,7 +809,7 @@ public static class NumberOptionPatch
 public static class StringOptionPatch
 {
     private static long HelpShowEndTS;
-    private static readonly Dictionary<StringOption, string> NameCache = new();
+    internal static readonly Dictionary<StringOption, string> NameCache = new();
 
     [HarmonyPatch(nameof(StringOption.Initialize))]
     [HarmonyPrefix]

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -22,8 +22,8 @@ public static class ModGameOptionsMenu
     public static readonly Dictionary<OptionBehaviour, int> OptionList = new();
     public static readonly Dictionary<int, OptionBehaviour> BehaviourList = new();
     public static readonly Dictionary<int, CategoryHeaderMasked> CategoryHeaderList = new();
-    public static readonly Dictionary<CustomRoles, Transform> HelpIconList = new();
-    public static readonly Dictionary<OptionItem, BaseGameSetting> BaseGameSettingCache = new();
+    public static readonly System.Collections.Generic.Dictionary<CustomRoles, Transform> HelpIconList = [];
+    public static readonly System.Collections.Generic.Dictionary<OptionItem, BaseGameSetting> BaseGameSettingCache = [];
 
     public static T Track<T>(T obj) where T : Object
     {

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -56,13 +56,6 @@ public static class GameOptionsMenuPatch
     {
         if (ModGameOptionsMenu.TabIndex < 3) return true;
 
-        // Cancel any in-progress build coroutine before re-initializing
-        if (_buildCoroutines.TryGetValue(__instance, out Coroutine existing) && existing != null)
-        {
-            __instance.StopCoroutine(existing);
-            _buildCoroutines.Remove(__instance);
-        }
-
         if (__instance.Children == null || __instance.Children.Count == 0)
         {
             __instance.MapPicker.gameObject.SetActive(false);
@@ -410,17 +403,13 @@ public static class GameOptionsMenuPatch
         _reCreateGeneration++;
         int generation = _reCreateGeneration;
 
-        // Use a persistent GameOptionsMenu as the coroutine host - these are never destroyed
-        GameOptionsMenu host = GameSettingMenuPatch.ModSettingsTabs.Values.FirstOrDefault(m => m && m.gameObject.activeInHierarchy);
-        if (!host) return;
-
         if (_reCreateAllCoroutine != null)
         {
-            host.StopCoroutine(_reCreateAllCoroutine);
+            Main.Instance.StopCoroutine(_reCreateAllCoroutine);
             _reCreateAllCoroutine = null;
         }
 
-        _reCreateAllCoroutine = host.StartCoroutine(CoReCreateAll(generation).WrapToIl2Cpp());
+        _reCreateAllCoroutine = Main.Instance.StartCoroutine(CoReCreateAll(generation).WrapToIl2Cpp());
 
         IEnumerator CoReCreateAll(int gen)
         {
@@ -449,7 +438,7 @@ public static class GameOptionsMenuPatch
     public static void ReCreateSettings(GameOptionsMenu __instance, TabGroup? modTab = null)
     {
         if (!modTab.HasValue && ModGameOptionsMenu.TabIndex < 3) return;
-        if (!__instance || !__instance.gameObject.activeInHierarchy) return;
+        if (!__instance) return;
 
         modTab ??= (TabGroup)(ModGameOptionsMenu.TabIndex - 3);
 
@@ -1601,8 +1590,7 @@ public static class GameSettingMenuPatch
 
         if (GameOptionsMenuPatch._reCreateAllCoroutine != null)
         {
-            GameOptionsMenu host = ModSettingsTabs.Values.FirstOrDefault();
-            if (host) host.StopCoroutine(GameOptionsMenuPatch._reCreateAllCoroutine);
+            Main.Instance.StopCoroutine(GameOptionsMenuPatch._reCreateAllCoroutine);
             GameOptionsMenuPatch._reCreateAllCoroutine = null;
         }
 
@@ -1702,4 +1690,4 @@ public static class FixDarkThemeForSearchBar
             field.textArea.outputText.color = Color.white;
         }
     }
-}
+    

--- a/Patches/GameOptionsMenuPatch.cs
+++ b/Patches/GameOptionsMenuPatch.cs
@@ -22,8 +22,8 @@ public static class ModGameOptionsMenu
     public static readonly Dictionary<OptionBehaviour, int> OptionList = new();
     public static readonly Dictionary<int, OptionBehaviour> BehaviourList = new();
     public static readonly Dictionary<int, CategoryHeaderMasked> CategoryHeaderList = new();
-    public static readonly System.Collections.Generic.Dictionary<CustomRoles, Transform> HelpIconList = [];
-    public static readonly System.Collections.Generic.Dictionary<OptionItem, BaseGameSetting> BaseGameSettingCache = [];
+    public static readonly Dictionary<CustomRoles, Transform> HelpIconList = new();
+    public static readonly Dictionary<OptionItem, BaseGameSetting> BaseGameSettingCache = new();
 
     public static T Track<T>(T obj) where T : Object
     {
@@ -48,11 +48,20 @@ public static class ModGameOptionsMenu
 [HarmonyPatch(typeof(GameOptionsMenu))]
 public static class GameOptionsMenuPatch
 {
+    internal static readonly Dictionary<GameOptionsMenu, Coroutine> _buildCoroutines = new();
+
     [HarmonyPatch(nameof(GameOptionsMenu.Initialize))]
     [HarmonyPrefix]
     private static bool InitializePrefix(GameOptionsMenu __instance)
     {
         if (ModGameOptionsMenu.TabIndex < 3) return true;
+
+        // Cancel any in-progress build coroutine before re-initializing
+        if (_buildCoroutines.TryGetValue(__instance, out Coroutine existing) && existing != null)
+        {
+            __instance.StopCoroutine(existing);
+            _buildCoroutines.Remove(__instance);
+        }
 
         if (__instance.Children == null || __instance.Children.Count == 0)
         {
@@ -117,7 +126,9 @@ public static class GameOptionsMenuPatch
     private static bool CreateSettingsPrefix(GameOptionsMenu __instance)
     {
         if (ModGameOptionsMenu.TabIndex < 3) return true;
-
+        
+        if (!__instance.gameObject.activeInHierarchy) return false;
+        
         var modTab = (TabGroup)(ModGameOptionsMenu.TabIndex - 3);
         
         if (modTab == TabGroup.PresetExplorer)
@@ -128,7 +139,14 @@ public static class GameOptionsMenuPatch
 
         __instance.scrollBar.SetYBoundsMax(CalculateScrollBarYBoundsMax());
 
-        __instance.StartCoroutine(CoRoutine().WrapToIl2Cpp());
+        // Cancel any in-progress build coroutine on this instance before starting a new one
+        if (_buildCoroutines.TryGetValue(__instance, out Coroutine existing) && existing != null)
+        {
+            __instance.StopCoroutine(existing);
+            _buildCoroutines.Remove(__instance);
+        }
+
+        _buildCoroutines[__instance] = __instance.StartCoroutine(CoRoutine().WrapToIl2Cpp());
         return false;
 
         IEnumerator CoRoutine()
@@ -138,7 +156,7 @@ public static class GameOptionsMenuPatch
             const float posZ = -2.0f;
 
             TextOptionItem header = null;
-
+            
             for (var index = 0; index < OptionItem.AllOptions.Count; index++)
             {
                 try
@@ -227,8 +245,11 @@ public static class GameOptionsMenuPatch
                     if (enabledOrNotCollapsed) num -= 0.45f;
                 }
                 catch (Exception e) { Utils.ThrowException(e); }
-
-                if (index % 100 == 0) yield return null;
+                
+                if (index % 100 == 0)
+                {
+                    yield return null;
+                }
             }
 
             __instance.ControllerSelectable.Clear();
@@ -349,6 +370,7 @@ public static class GameOptionsMenuPatch
             }
         }
     }
+
     [HarmonyPatch(nameof(GameOptionsMenu.Update))]
     [HarmonyPrefix]
     public static void UpdatePostfix(GameOptionsMenu __instance)
@@ -358,6 +380,7 @@ public static class GameOptionsMenuPatch
 
         __instance.scrollBar.enabled = !HudManager.Instance.Chat.IsOpenOrOpening;
     }
+
     [HarmonyPatch(nameof(GameOptionsMenu.ValueChanged))]
     [HarmonyPrefix]
     private static bool ValueChangedPrefix(GameOptionsMenu __instance, OptionBehaviour option)
@@ -379,9 +402,54 @@ public static class GameOptionsMenuPatch
         ReCreateSettings(menu, tab);
     }
 
+    internal static int _reCreateGeneration;
+    internal static Coroutine _reCreateAllCoroutine;
+
+    public static void ReCreateAllSettings()
+    {
+        _reCreateGeneration++;
+        int generation = _reCreateGeneration;
+
+        // Use a persistent GameOptionsMenu as the coroutine host - these are never destroyed
+        GameOptionsMenu host = GameSettingMenuPatch.ModSettingsTabs.Values.FirstOrDefault(m => m && m.gameObject.activeInHierarchy);
+        if (!host) return;
+
+        if (_reCreateAllCoroutine != null)
+        {
+            host.StopCoroutine(_reCreateAllCoroutine);
+            _reCreateAllCoroutine = null;
+        }
+
+        _reCreateAllCoroutine = host.StartCoroutine(CoReCreateAll(generation).WrapToIl2Cpp());
+
+        IEnumerator CoReCreateAll(int gen)
+        {
+            TabGroup[] tabs = Main.TabGroupValues;
+            foreach (TabGroup tab in tabs)
+            {
+                if (gen != _reCreateGeneration) yield break;
+
+                // Stop any build coroutine that started during the yield before touching this tab
+                if (GameSettingMenuPatch.ModSettingsTabs.TryGetValue(tab, out GameOptionsMenu menu) && menu)
+                {
+                    if (_buildCoroutines.TryGetValue(menu, out Coroutine existing) && existing != null)
+                    {
+                        menu.StopCoroutine(existing);
+                        _buildCoroutines.Remove(menu);
+                    }
+                }
+
+                ReCreateSettings(tab);
+                yield return null;
+            }
+            _reCreateAllCoroutine = null;
+        }
+    }
+
     public static void ReCreateSettings(GameOptionsMenu __instance, TabGroup? modTab = null)
     {
         if (!modTab.HasValue && ModGameOptionsMenu.TabIndex < 3) return;
+        if (!__instance || !__instance.gameObject.activeInHierarchy) return;
 
         modTab ??= (TabGroup)(ModGameOptionsMenu.TabIndex - 3);
 
@@ -395,7 +463,7 @@ public static class GameOptionsMenuPatch
             bool enabledOrNotCollapsed = !option.IsCurrentlyHidden() && AllParentsEnabledAndVisible(option.Parent);
             bool enabled = !option.IsCurrentlyHidden(checkCollapsedSection: false) && AllParentsEnabledAndVisible(option.Parent, checkCollapsedSection: false);
 
-            if (ModGameOptionsMenu.CategoryHeaderList.TryGetValue(index, out CategoryHeaderMasked categoryHeaderMasked))
+            if (ModGameOptionsMenu.CategoryHeaderList.TryGetValue(index, out CategoryHeaderMasked categoryHeaderMasked) && categoryHeaderMasked)
             {
                 categoryHeaderMasked.transform.localPosition = new(-0.903f, num, -2f);
                 categoryHeaderMasked.gameObject.SetActive(enabled);
@@ -403,7 +471,7 @@ public static class GameOptionsMenuPatch
             }
             else if (option.IsHeader && enabledOrNotCollapsed) num -= 0.18f;
 
-            if (ModGameOptionsMenu.BehaviourList.TryGetValue(index, out OptionBehaviour optionBehaviour))
+            if (ModGameOptionsMenu.BehaviourList.TryGetValue(index, out OptionBehaviour optionBehaviour) && optionBehaviour)
             {
                 optionBehaviour.transform.localPosition = new(0.952f, num, -2f);
                 optionBehaviour.gameObject.SetActive(enabledOrNotCollapsed);
@@ -411,6 +479,7 @@ public static class GameOptionsMenuPatch
             }
         }
 
+        if (!__instance.scrollBar) return;
         __instance.ControllerSelectable.Clear();
 
         foreach (UiElement x in __instance.scrollBar.GetComponentsInChildren<UiElement>())
@@ -425,6 +494,8 @@ public static class GameOptionsMenuPatch
         foreach (KeyValuePair<OptionBehaviour, int> kvp in ModGameOptionsMenu.OptionList)
         {
             OptionBehaviour optionBehaviour = kvp.Key;
+            if (!optionBehaviour) continue;
+
             OptionItem optionItem = OptionItem.AllOptions[kvp.Value];
 
             switch (optionItem)
@@ -435,9 +506,15 @@ public static class GameOptionsMenuPatch
                     toggleOption.CheckMark.enabled = optionItem.GetBool();
                     toggleOption.CheckMark.transform.parent.FindChild("ActiveSprite").GetComponent<SpriteRenderer>().color = color;
                     break;
-                case StringOptionItem when optionBehaviour is StringOption stringOption:
-                    stringOption.Value = optionItem.GetInt();
-                    stringOption.UpdateValue();
+                case StringOptionItem stringOptionItem when optionBehaviour is StringOption stringOption:
+                    // Set Value directly without calling UpdateValue() to avoid re-entering the patch pipeline
+                    stringOption.Value = stringOptionItem.GetInt();
+                    stringOption.oldValue = stringOption.Value;
+                    string selection = stringOptionItem.Selections[stringOptionItem.Rule.GetValueByIndex(stringOption.Value)];
+                    if (!stringOptionItem.noTranslation) selection = Translator.GetString(selection);
+                    stringOption.ValueText.SetText(selection);
+                    // Re-initialize to restore styled role name (size, color) after preset switch
+                    stringOption.Initialize();
                     break;
                 case FloatOptionItem or IntegerOptionItem when optionBehaviour is NumberOption numberOption:
                     numberOption.Value = optionItem.GetFloat();
@@ -855,7 +932,9 @@ public static class StringOptionPatch
 
         gameOptionButton.interactableColor = Color.black;
         gameOptionButton.interactableHoveredColor = ModGameOptionsMenu.GetCurrentThemeColor();
-        icon.localPosition += new Vector3(-0.8f, 0f, 0f);
+        // Only apply position offset on first creation, not on reuse (prevents icon drifting left on switching presets)
+        if (!cached)
+            icon.localPosition += new Vector3(-0.8f, 0f, 0f);
         icon.SetAsLastSibling();
         ModGameOptionsMenu.HelpIconList[role] = icon;
     }
@@ -900,7 +979,10 @@ public static class StringOptionPatch
             OptionItem item = OptionItem.AllOptions[index];
             item.SetValue(__instance.GetInt(), doSave: true, doSync: false);
             NotificationPopperPatch.AddSettingsChangeMessage(item);
-            __instance.TitleText.SetText(NameCache[__instance]);
+            if (!NameCache.ContainsKey(__instance))
+                __instance.Initialize();
+            else
+                __instance.TitleText.SetText(NameCache[__instance]);
             return false;
         }
 
@@ -1137,7 +1219,7 @@ public static class GameSettingMenuPatch
             ChangingPreset = true;
             LastPresetChange = Utils.TimeStamp;
             Options.Preset--;
-            Main.TabGroupValues.Do(GameOptionsMenuPatch.ReCreateSettings);
+            GameOptionsMenuPatch.ReCreateAllSettings();
             GameOptionsMenuPatch.RefreshSettingValues();
             GameOptionsMenuPatch.RefreshTabButtons();
             presetTmp.SetText(Translator.GetString($"Preset_{OptionItem.CurrentPreset + 1}"));
@@ -1187,7 +1269,7 @@ public static class GameSettingMenuPatch
             ChangingPreset = true;
             LastPresetChange = Utils.TimeStamp;
             Options.Preset++;
-            Main.TabGroupValues.Do(GameOptionsMenuPatch.ReCreateSettings);
+            GameOptionsMenuPatch.ReCreateAllSettings();
             GameOptionsMenuPatch.RefreshSettingValues();
             GameOptionsMenuPatch.RefreshTabButtons();
             presetTmp.SetText(Translator.GetString($"Preset_{OptionItem.CurrentPreset + 1}"));
@@ -1432,7 +1514,8 @@ public static class GameSettingMenuPatch
                 {
                     OnlinePresetsManager.CachedPresets = list;
                     OnlinePresetsManager.PresetsLoaded = true;
-                    OnlinePresetsManager.CreatePresetExplorerUI(ModSettingsTabs[tabGroup]);
+                    if (ModSettingsTabs.TryGetValue(tabGroup, out settingsTab) && settingsTab)
+                        OnlinePresetsManager.CreatePresetExplorerUI(settingsTab);
                 }).WrapToIl2Cpp()
             );
         }
@@ -1513,7 +1596,24 @@ public static class GameSettingMenuPatch
             go.SetActive(true);
             TempParent = go.transform;
         }
-        
+
+        GameOptionsMenuPatch._reCreateGeneration++;
+
+        if (GameOptionsMenuPatch._reCreateAllCoroutine != null)
+        {
+            GameOptionsMenu host = ModSettingsTabs.Values.FirstOrDefault();
+            if (host) host.StopCoroutine(GameOptionsMenuPatch._reCreateAllCoroutine);
+            GameOptionsMenuPatch._reCreateAllCoroutine = null;
+        }
+
+        // Clear GMButton listeners before hiding them so they can't fire stale callbacks
+        foreach (var x in GMButtons.Values)
+        {
+            var pb = x.GetComponent<PassiveButton>();
+            if (pb) pb.OnClick.RemoveAllListeners();
+            SetTempParent(x);
+        }
+
         foreach (var x in ModSettingsTabs.Values) SetTempParent(x.gameObject);
         foreach (var x in ModSettingsButtons.Values) SetTempParent(x.gameObject);
         foreach (var x in ExtraObjectsCache.Values) SetTempParent(x);


### PR DESCRIPTION
## Summary
Fixes multiple native crashes (`SIGSEGV` in `libil2cpp.so`) specifically on Android that occurred during rapid tab switching, preset switching, and lobby exit. Also fixes a visible freeze when switching presets.

Most of the explanation in this PR is AI generated because honestly these crashes were so deep in IL2CPP internals that explaining them in human words felt like I need a Phd in Low Level Programming 🫠

---

## Changes

### `NameCache` bare indexer in `UpdateValuePrefix`

`NameCache[__instance]` was used without a guard. If a `StringOption` was in `OptionList` but hadn't gone through `InitializePrefix`, this crashed. Now calls `__instance.Initialize()` on a cache miss instead.

### `StopCoroutine` called on the wrong instance

`_buildCoroutine` was a single static field shared across all tab instances. When rapidly switching tabs, `StopCoroutine` was being called on the wrong `GameOptionsMenu`, causing a native null dereference. Also meant multiple build coroutines could run simultaneously and corrupt each other's `OnValueChanged` listeners.

Replaced with `Dictionary<GameOptionsMenu, Coroutine> _buildCoroutines` so each tab manages its own coroutine.

### `UpdateValue()` call in `RefreshSettingValues` causing re-entrancy

Calling `stringOption.UpdateValue()` during preset switching triggered the patch pipeline, which called `SetValue()`, which fired change notifications, which called `ReCreateSettings()` - all while `RefreshSettingValues` was still iterating `OptionList`. IL2CPP dictionaries don't throw on structural modification during iteration, they just corrupt silently (fault address `0x100000000`).

`RefreshSettingValues` now updates string option display state directly without going through `UpdateValue()`.

### Preset switching rebuilding all tabs synchronously

`Main.TabGroupValues.Do(ReCreateSettings)` rebuilt every tab in one frame, causing a visible freeze. Replaced with `ReCreateAllSettings()` which runs as a coroutine and rebuilds one tab per frame.