### PR TITLE
Add branch name parameters for Crowdin action

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -17,6 +17,8 @@ jobs:
       - name: upload sources to crowdin
         uses: crowdin/github-action@v2
         with:
+          crowdin_branch_name: main
+          localization_branch_name: main
           upload_sources: true
           download_sources: false
         env:


### PR DESCRIPTION
Fixed the reason why Crowdin added second file
Now it won't happen, but second files in all translations need to be removed manually