### PR TITLE
Add Device Positions for LevelImpostor Maps (Experimental)

### DIFF
--- a/Modules/CustomRoleSelector.cs
+++ b/Modules/CustomRoleSelector.cs
@@ -108,8 +108,6 @@ internal static class CustomRoleSelector
 
             switch (role)
             {
-                case CustomRoles.Bargainer when Main.LIMap:
-                case CustomRoles.AntiAdminer when Main.LIMap:
                 case CustomRoles.CameraMan when Main.LIMap:
                 case CustomRoles.Weatherman when Main.LIMap || GameStates.CurrentServerType == GameStates.ServerType.Vanilla:
                 case CustomRoles.Doctor when Options.EveryoneSeesDeathReasons.GetBool():

--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -39,6 +39,29 @@ internal static class DisableDevice
         ["SubmergedCamera"] = new(-3.41f, -34.56f)
     };
 
+    public static void AddCustomDevicesPos()
+    {
+        var keysToRemove = DevicePos.Keys
+            .Where(k => k.StartsWith("LI", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        foreach (var key in keysToRemove)
+            DevicePos.Remove(key);
+
+        int adminId = 0;
+        int cameraId = 0;
+        int vitalId = 0;
+
+        foreach (var admin in Object.FindObjectsOfType<MapConsole>(true))
+            DevicePos[$"LIAdmin{adminId++}"] = admin.transform.position;
+
+        foreach (var console in Object.FindObjectsOfType<SystemConsole>(true))
+        {
+            if (console.name == "Surv_Panel") DevicePos[$"LICamera{cameraId++}"] = console.transform.position;
+            else if (console.name.Contains("Vital")) DevicePos[$"LIVital{vitalId++}"] = console.transform.position;
+        }
+    }
+
     private static bool DoDisable => Options.DisableDevices.GetBool();
 
     public static float UsableDistance => Main.CurrentMap switch
@@ -166,6 +189,8 @@ public class RemoveDisableDevicesPatch
 {
     public static void Postfix()
     {
+        if (Main.LIMap) DisableDevice.AddCustomDevicesPos();
+
         bool rogueForce = Rogue.On && Main.PlayerStates.Values.Any(x => x.Role is Rogue { DisableDevices: true });
         if (!Options.DisableDevices.GetBool() && !rogueForce) return;
 

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -3929,7 +3929,7 @@ public static class Utils
                     nums[Options.GameStateInfo.NKCount]++;
                 else if (pc.Is(Team.Impostor))
                     nums[Options.GameStateInfo.ImpCount]++;
-                else if (pc.IsCrewmate())
+                else if (pc.Is(Team.Crewmate))
                     nums[Options.GameStateInfo.CrewCount]++;
                 else if (pc.Is(Team.Neutral))
                     nums[Options.GameStateInfo.NNKCount]++;

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -3927,10 +3927,10 @@ public static class Utils
                     nums[Options.GameStateInfo.MadmateCount]++;
                 else if (pc.IsNeutralKiller())
                     nums[Options.GameStateInfo.NKCount]++;
-                else if (pc.IsCrewmate())
-                    nums[Options.GameStateInfo.CrewCount]++;
                 else if (pc.Is(Team.Impostor))
                     nums[Options.GameStateInfo.ImpCount]++;
+                else if (pc.IsCrewmate())
+                    nums[Options.GameStateInfo.CrewCount]++;
                 else if (pc.Is(Team.Neutral))
                     nums[Options.GameStateInfo.NNKCount]++;
                 else if (pc.Is(Team.Coven))

--- a/Roles/Standard/Crewmate/Investigate/Sentry.cs
+++ b/Roles/Standard/Crewmate/Investigate/Sentry.cs
@@ -87,7 +87,8 @@ internal class Sentry : RoleBase
 
         AvailableDevices = DisableDevice.DevicePos.Where(x =>
         {
-            bool correctMap = x.Key.Contains(Main.CurrentMap.ToString(), StringComparison.OrdinalIgnoreCase);
+            string mapName = SubmergedCompatibility.IsSubmerged() ? "Submerged" : Main.LIMap ? "LI" : Main.CurrentMap.ToString();
+            bool correctMap = x.Key.Contains(mapName, StringComparison.OrdinalIgnoreCase);
             var devicesOpt = (UsableDevicesStrings)UsableDevicesForInfoView.GetValue();
 
             bool enabled = devicesOpt switch

--- a/Roles/Standard/Crewmate/Support/TimeMaster.cs
+++ b/Roles/Standard/Crewmate/Support/TimeMaster.cs
@@ -258,6 +258,7 @@ internal class TimeMaster : RoleBase
                 4 => FastVector2.DistanceWithinRange(pos, DisableDevice.DevicePos["AirshipVital"], usableDistance),
                 5 => FastVector2.DistanceWithinRange(pos, DisableDevice.DevicePos["FungleVital"], usableDistance),
                 6 when SubmergedCompatibility.IsSubmerged() => FastVector2.DistanceWithinRange(pos, DisableDevice.DevicePos["SubmergedVital"], usableDistance),
+                7 => DisableDevice.DevicePos.Any(kvp => kvp.Key.StartsWith("LIVital") && FastVector2.DistanceWithinRange(pos, kvp.Value, usableDistance)),
                 _ => false
             };
         }

--- a/Roles/Standard/Impostor/Miscellaneous/AntiAdminer.cs
+++ b/Roles/Standard/Impostor/Miscellaneous/AntiAdminer.cs
@@ -299,6 +299,34 @@ internal class AntiAdminer : RoleBase
 
                         break;
                     }
+                    case 7:
+                    {
+                        foreach (var (key, position) in DisableDevice.DevicePos)
+                        {
+                            if (!key.StartsWith("LIVital") && !key.StartsWith("LIAdmin") && !key.StartsWith("LICamera")) continue;
+
+                            if (FastVector2.DistanceWithinRange(playerPos, position, usableDistance))
+                            {
+                                if (key.StartsWith("LIVital"))
+                                {
+                                    vital = true;
+                                    AddDeviceUse(playerId, Device.Vitals);
+                                }
+                                else if (key.StartsWith("LIAdmin"))
+                                {
+                                    admin = true;
+                                    AddDeviceUse(playerId, Device.Admin);
+                                }
+                                else if (key.StartsWith("LICamera"))
+                                {
+                                    camera = true;
+                                    AddDeviceUse(playerId, Device.Camera);
+                                }
+                            }
+                        }
+                        
+                        break;
+                    }
                 }
             }
             catch (Exception ex) { Logger.Error(ex.ToString(), "AntiAdminer"); }

--- a/Roles/Standard/Neutral/Killing/Bargainer.cs
+++ b/Roles/Standard/Neutral/Killing/Bargainer.cs
@@ -79,8 +79,7 @@ internal class Bargainer : RoleBase
     {
         get
         {
-            var mapName = Main.CurrentMap.ToString();
-            if (SubmergedCompatibility.IsSubmerged()) mapName = "Submerged";
+            var mapName = SubmergedCompatibility.IsSubmerged() ? "Submerged" : Main.LIMap ? "LI" : Main.CurrentMap.ToString();
             return DisableDevice.DevicePos.Where(x => x.Key.StartsWith(mapName)).Select(x => x.Value);
         }
     }


### PR DESCRIPTION
# Summary
Add Device Positions for LevelImpostor Maps (Experimental)

## What type of PR is this? (check all that apply)
- [x] Bug Fix
- [x] New Feature
- [ ] Refactor / Optimization
- [ ] Documentation Update
- [ ] Other

## Description
On `ShipStatus.Start` patch, if `Main.LIMap` is true (aka playing on a LI map) it will start `AddCustomDevicesPos()`, which will add the positions (`console.transform.position`) named `LIAdmin`, `LICamera` and `LIVital` with ids depending on how many devices are there. MapConsole is Admin, while SystemConsole can be splitted to Camera (name is known as `Surv_Panel` due to LI src) and Vital (currently unknown about the console's name, which I'll just assume it has Vital in it). Additions was made as Time Master will have Vitals disabled, players can access Sentry's monitored room, AntiAdminer & Telecommunication works, and Bargainer can buy items. In addition, tried to make Double Agent shows as Impostor by putting `pc.Is(Team.Impostor)` before `pc.IsCrewmate()`, and changed `pc.IsCrewmate()` to `pc.Is(Team.Crewmate)` to properly show Trickster as Crewmate team.

## Related issue or discussion
<!---
Link any related issue, suggestion, or discussion below.
If this was discussed or suggested on Discord, include a link or brief description of the relevant message or thread.
-->

## Screenshots / Videos
<!---
If your change affects anything visual or gameplay-related, attach screenshots or a short video.
Not required for pure refactors or translation updates.
-->

## Checklist
<!--- Put an `x` in the boxes that apply, e.g. - [x] I have read CONTRIBUTING.md -->

- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md) and my changes follow its guidelines
- [x] I have read the [AI Policy](./AI_POLICY.md) and I am complying with it
- [x] I have performed a self-review of my own code and it follows the code style of this project
- [x] I understand every part of the code I am submitting and can explain it if asked
- [x] I have commented my code where the logic is not immediately obvious
- [x] I have tested my changes in-game and they work as expected
- [x] My changes do not break any existing functionality I am aware of
- [x] I have not left behind debug code, commented-out blocks, or unnecessary logging
- [x] I added or updated translation keys if applicable
- [x] If this adds a new role, add-on, game mode, or option, it is properly registered

## AI usage declaration
None
