### PR TITLE
Final Touches

### DIFF
--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -6,6 +6,7 @@ using HarmonyLib;
 using Hazel;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using UnityEngine;
+using static EHR.Modules.LevelImposterCompatibility;
 
 namespace EHR;
 
@@ -50,16 +51,20 @@ internal static class DisableDevice
 
         int adminId = 0;
         int cameraId = 0;
+        int binoId = 0;
         int vitalId = 0;
 
-        foreach (var admin in Object.FindObjectsOfType<MapConsole>(true))
+        foreach (var admin in AllAdminTables)
             DevicePos[$"LIAdmin{adminId++}"] = admin.transform.position;
 
-        foreach (var console in Object.FindObjectsOfType<SystemConsole>(true))
-        {
-            if (console.name == "Surv_Panel") DevicePos[$"LICamera{cameraId++}"] = console.transform.position;
-            else if (console.name.Contains("Vital")) DevicePos[$"LIVital{vitalId++}"] = console.transform.position;
-        }
+        foreach (var camera in AllCameraPanels)
+            DevicePos[$"LICamera{cameraId++}"] = camera.transform.position;
+
+        foreach (var bino in AllBinoculars)
+            DevicePos[$"LIBinocular{binoId++}"] = bino.transform.position;
+
+        foreach (var vital in AllVitals)
+            DevicePos[$"LIVital{vitalId++}"] = vital.transform.position;
     }
 
     private static bool DoDisable => Options.DisableDevices.GetBool();

--- a/Roles/Standard/Crewmate/Investigate/Sentry.cs
+++ b/Roles/Standard/Crewmate/Investigate/Sentry.cs
@@ -106,8 +106,8 @@ internal class Sentry : RoleBase
                 {
                     AdditionalDevicesStrings.None => false,
                     AdditionalDevicesStrings.DoorLog => x.Key.Contains("DoorLog"),
-                    AdditionalDevicesStrings.Binoculars => x.Key.Contains("Camera") && x.Key.Contains("Fungle"),
-                    AdditionalDevicesStrings.DoorLogAndBinoculars => x.Key.Contains("DoorLog") || (x.Key.Contains("Camera") && x.Key.Contains("Fungle")),
+                    AdditionalDevicesStrings.Binoculars => x.Key.Contains("Camera") && x.Key.Contains("Fungle") || x.Key.Contains("Binocular"),
+                    AdditionalDevicesStrings.DoorLogAndBinoculars => x.Key.Contains("DoorLog") || (x.Key.Contains("Camera") && x.Key.Contains("Fungle")) || x.Key.Contains("Binocular"),
                     _ => false
                 };
             }


### PR DESCRIPTION
# Summary
Add some final touches on Zypherus' pull request

## What type of PR is this? (check all that apply)
<!--- Put an `x` in the boxes that apply, e.g. - [x] Bug Fix -->

- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor / Optimization
- [ ] Documentation Update
- [ ] Other

## Description
Change from `Object.FindObjectsOfType<...>()` to their appropriate GameObject source, used static `EHR.LevelImposterCompatibility` to avoid repetitions, Binoculars are now considered their own type of device instead of Camera. Sentry now support LI's Binoculars as additional devices

## Related issue or discussion
<!---
Link any related issue, suggestion, or discussion below.
If this was discussed or suggested on Discord, include a link or brief description of the relevant message or thread.
-->

## Screenshots / Videos
<!---
If your change affects anything visual or gameplay-related, attach screenshots or a short video.
Not required for pure refactors or translation updates.
-->

## Checklist
<!--- Put an `x` in the boxes that apply, e.g. - [x] I have read CONTRIBUTING.md -->

- [x] I have read [CONTRIBUTING.md](./CONTRIBUTING.md) and my changes follow its guidelines
- [x] I have read the [AI Policy](./AI_POLICY.md) and I am complying with it
- [x] I have performed a self-review of my own code and it follows the code style of this project
- [x] I understand every part of the code I am submitting and can explain it if asked
- [x] I have commented my code where the logic is not immediately obvious
- [x] I have tested my changes in-game and they work as expected
- [x] My changes do not break any existing functionality I am aware of
- [x] I have not left behind debug code, commented-out blocks, or unnecessary logging
- [ ] I added or updated translation keys if applicable
- [ ] If this adds a new role, add-on, game mode, or option, it is properly registered

## AI usage declaration
<!--- 
Write "None" if you did not use AI. If you did, declare what you used it for. 
The AI Policy you agreed to above covers the rest. 
-->
